### PR TITLE
Check for stopped docker containers

### DIFF
--- a/Docker/expbox
+++ b/Docker/expbox
@@ -163,7 +163,7 @@ else
 
     until (( PORT > LAST ))
     do
-	if [[ -z `sudo lsof -i ":$PORT"` ]] && [[ -z `docker ps -q -f name="expbox_$PORT"` ]]; then
+	if [[ -z `sudo lsof -i ":$PORT"` ]] && [[ -z `docker ps -a -q -f name="expbox_$PORT"` ]]; then
 	    if ((verbose > 0)); then
 		printf 'Found available port=<%d>\n' $PORT;
 	    fi


### PR DESCRIPTION
The current script uses `lsof -i` to check for ports and  uses the `docker` command to check for active containers.  This commit adds the `-a` flag to check for active _and_ stopped containers.  This update will prevent an error from docker finding a stopped container with the same name