### PR TITLE
Minor updates to HPCCM file for Docker to fix minor issues

### DIFF
--- a/Docker/exp_all_deb.py
+++ b/Docker/exp_all_deb.py
@@ -79,7 +79,7 @@ Stage1 += Stage0.runtime(_from='devel')
 
 Stage1 += compiler
 
-Stage1 += apt_get(ospackages=['libpython3.10-dev', 'libopenmpi-dev', 'openmpi-bin', 'less', 'libfftw3-3', 'libhdf5-dev', 'libhdf5-103', 'libhdf5-cpp-103', 'ffmpeg', 'nano', 'libgsl-dev', 'libeigen3-dev', 'python3.10-dev', 'dvipng', 'unzip', 'make', 'busybox', 'apache2', 'apache2-utils'])
+Stage1 += apt_get(ospackages=['libpython3.10-dev', 'libopenmpi-dev', 'openmpi-bin', 'less', 'libfftw3-3', 'libhdf5-dev', 'libhdf5-103', 'libhdf5-cpp-103', 'ffmpeg', 'nano', 'libgsl-dev', 'libeigen3-dev', 'python3.10-dev', 'dvipng', 'unzip', 'make', 'busybox'])
 
 # Install EXP into the runtime image
 #
@@ -100,7 +100,3 @@ Stage1 += environment(variables={'LD_LIBRARY_PATH': '/usr/local/EXP/lib'})
 #
 Stage1 += environment(variables={'PYTHONPATH': '/usr/local/EXP/lib/python3.10/site-packages'})
 Stage1 += pip(packages=['numpy', 'scipy', 'matplotlib', 'jupyter', 'h5py', 'mpi4py', 'PyYAML', 'k3d', 'pandas', 'astropy', 'gala', 'galpy', 'jupyterlab', 'ipyparallel'], pip='pip3', upgrade=True, ospackages=['python3-pip', 'python3-setuptools', 'python3-wheel', 'python3-pip-whl'])
-
-# Jupyter Lab workaround
-#
-Stage1 += shell(commands=['yes | pip3 uninstall traitlets', 'pip install traitlets==5.9.0'])


### PR DESCRIPTION
**Fixes**

1. Remove `apache` packages which are no longer needed since we are using `busybox` to serve web pages
2. Ditch `traitlets` version fix which now causes `ipython` to break