### PR TITLE
Install gala from source with EXP support

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -25,7 +25,7 @@
 
 FROM ubuntu:24.04 AS devel
 
-ARG BRANCH=main
+ARG BRANCH=v7.9.1
 
 # GNU compiler
 RUN apt-get update -y && \
@@ -134,6 +134,8 @@ COPY --from=devel /usr/local/EXP/bin /usr/local/EXP/bin
 
 COPY --from=devel /usr/local/EXP/lib /usr/local/EXP/lib
 
+COPY --from=devel /usr/local/EXP/include /usr/local/EXP/include 
+
 RUN mkdir -p /var/www/html && \
     cd /var/www/html && \
     wget -r -nH --cut-dirs=1 https://exp-code.github.io/EXP-docs/
@@ -160,17 +162,24 @@ RUN apt-get update -y && \
         python3-setuptools \
         python3-wheel && \
     rm -rf /var/lib/apt/lists/*
-RUN /opt/venv/bin/pip3 --no-cache-dir install numpy scipy matplotlib jupyter h5py mpi4py PyYAML k3d pandas astropy gala galpy pynbody jupyterlab jupyterhub ipyparallel
+
+RUN /opt/venv/bin/pip3 --no-cache-dir install numpy scipy matplotlib jupyter h5py mpi4py PyYAML k3d pandas astropy galpy pynbody jupyterlab jupyterhub ipyparallel
 
 RUN pip3 install --config-settings --build-option=--yes --no-build-isolation agama
+
+# Install gala from source with EXP support
+RUN cd /usr/local && \ 
+    export GIT_SSL_NO_VERIFY=1 && \
+    git clone https://github.com/adrn/gala.git && \
+    cd gala && \
+    export GALA_EXP_PREFIX=/usr/local/EXP/ && \
+    python3 -m pip install -ve .
 
 RUN cd /usr/local && \
     export GIT_SSL_NO_VERIFY=1 && \
     git clone https://github.com/EXP-code/EXP-examples EXP-examples && \
     git clone https://github.com/EXP-code/pyEXP-examples pyEXP-examples && \
-    git clone https://github.com/EXP-code/EXP-tools && \
-    cd pyEXP-examples && \
-    git checkout haloVel
+    git clone https://github.com/EXP-code/EXP-tools
 
 RUN chmod -R 777 /opt/venv && \
     chmod -R 777 /usr/local/pyEXP-examples && \

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -25,7 +25,7 @@
 
 FROM ubuntu:24.04 AS devel
 
-ARG BRANCH=v7.9.1
+ARG BRANCH=main
 
 # GNU compiler
 RUN apt-get update -y && \

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -17,6 +17,9 @@
 #   or
 #     $ docker buildx build --platform=linux/amd64,linux/arm64 -t the9cat/exp:latest --push -f Dockerfile .
 # 
+#   * You may requiest a particular branch_name using:
+#     $ hpccm --recipe exp_all_deb.py --format docker --userarg branch=branch_name > Dockerfile
+# 
 #   * You will need to put the EXP.tar.gz file in the build directory. I
 #     like to make a fresh clone and run `git submodule update --init
 #     --recursive` before tarring it up.
@@ -24,8 +27,6 @@
 # 
 
 FROM ubuntu:24.04 AS devel
-
-ARG BRANCH=main
 
 # GNU compiler
 RUN apt-get update -y && \
@@ -59,7 +60,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 
 # https://github.com/EXP-code/EXP.git
-RUN mkdir -p /var/tmp && cd /var/tmp && git clone --depth=1 --branch $BRANCH https://github.com/EXP-code/EXP.git EXP && cd - && \
+RUN mkdir -p /var/tmp && cd /var/tmp && git clone --depth=1 --branch main https://github.com/EXP-code/EXP.git EXP && cd - && \
     cd /var/tmp/EXP && \
     git config --global --add safe.directory /var/tmp/EXP && \
     git config --global --add safe.directory /var/tmp/EXP/extern/HighFive && \
@@ -134,7 +135,7 @@ COPY --from=devel /usr/local/EXP/bin /usr/local/EXP/bin
 
 COPY --from=devel /usr/local/EXP/lib /usr/local/EXP/lib
 
-COPY --from=devel /usr/local/EXP/include /usr/local/EXP/include 
+COPY --from=devel /usr/local/EXP/include /usr/local/EXP/include
 
 RUN mkdir -p /var/www/html && \
     cd /var/www/html && \
@@ -162,13 +163,11 @@ RUN apt-get update -y && \
         python3-setuptools \
         python3-wheel && \
     rm -rf /var/lib/apt/lists/*
-
-RUN /opt/venv/bin/pip3 --no-cache-dir install numpy scipy matplotlib jupyter h5py mpi4py PyYAML k3d pandas astropy galpy pynbody jupyterlab jupyterhub ipyparallel
+RUN /opt/venv/bin/pip3 --no-cache-dir install numpy scipy matplotlib jupyter h5py mpi4py PyYAML pandas astropy galpy pynbody jupyterlab jupyterlab_widgets ipywidgets k3d==2.16.1 jupyterhub ipyparallel
 
 RUN pip3 install --config-settings --build-option=--yes --no-build-isolation agama
 
-# Install gala from source with EXP support
-RUN cd /usr/local && \ 
+RUN cd /usr/local && \
     export GIT_SSL_NO_VERIFY=1 && \
     git clone https://github.com/adrn/gala.git && \
     cd gala && \

--- a/Docker/exp_all_deb.py
+++ b/Docker/exp_all_deb.py
@@ -7,6 +7,7 @@ Contents:
   * GNU compilers (upstream)
   * Python 2 and 3 (upstream)
   * OpenMPI, FFTW3, HDF5, Eigen3, PNG (upstream)
+  * EXP, EXP-examples, pyEXP-examples, EXP-docs
 
 Build notes:
 
@@ -15,6 +16,9 @@ Build notes:
     $ docker build -t exp-test -f Dockerfile .
   or
     $ docker buildx build --platform=linux/amd64,linux/arm64 -t the9cat/exp:latest --push -f Dockerfile .
+
+  * You may requiest a particular branch_name using:
+    $ hpccm --recipe exp_all_deb.py --format docker --userarg branch=branch_name > Dockerfile
 
   * You will need to put the EXP.tar.gz file in the build directory. I
     like to make a fresh clone and run `git submodule update --init
@@ -27,6 +31,8 @@ runtime_image = 'ubuntu:24.04'
 ##############
 # Devel stage
 ##############
+
+BRANCH = USERARG.get('branch', 'devel')
 
 Stage0 += comment(__doc__, reformat=False)
 
@@ -48,7 +54,8 @@ Stage0 += apt_get(ospackages=['libopenmpi-dev', 'openmpi-bin',
                               'libhdf5-hl-cpp-100t64',
                               'libeigen3-dev', 'libpng-dev',
                               'python3', '2to3', 'python3-dev',
-                              'wget', 'git', 'tar', 'cmake', 'make'])
+                              'ca-certificates', 'wget', 'git', 'tar',
+                              'cmake', 'make'])
 
 # Create a build directory and configure EXP.  The options below
 # should give you all that you need for most cases. Add additional
@@ -64,13 +71,21 @@ Stage0 += generic_cmake(
                 '-D FFTW_INCLUDE_DIRS=/usr/include/fftw3',
                 '-D Eigen3_DIR=/usr/share/eigen3/cmake',
                 '-D CMAKE_INSTALL_PREFIX=/usr/local/EXP'],
-    preconfigure=['git config --global --add safe.directory /var/tmp/EXP', 'git config --global --add safe.directory /var/tmp/EXP/extern/HighFive', 'git config --global --add safe.directory /var/tmp/EXP/extern/pybind11', 'git config --global --add safe.directory /var/tmp/EXP/extern/yaml-cpp', 'git config --global --add safe.directory /var/tmp/EXP/extern/HighFive/deps/catch2', 'mkdir -p /usr/local/EXP/doc', 'cp -a /var/tmp/EXP/sphinx/* /usr/local/EXP/doc'],
+    preconfigure=[
+        'git config --global --add safe.directory /var/tmp/EXP',
+        'git config --global --add safe.directory /var/tmp/EXP/extern/HighFive',
+        'git config --global --add safe.directory /var/tmp/EXP/extern/pybind11',
+        'git config --global --add safe.directory /var/tmp/EXP/extern/yaml-cpp',
+        'git config --global --add safe.directory /var/tmp/EXP/extern/HighFive/deps/catch2'
+    ],
     prefix='/usr/local/EXP',
     runtime_environment={
         'LD_LIBRARY_PATH': '/usr/local/EXP/lib',
         'LIBRARY_PATH': '/usr/local/EXP/lib',
         'PATH': '/usr/local/EXP/bin:${PATH}'},
-    package='EXP.tar.gz'
+    repository='https://github.com/EXP-code/EXP.git',
+    repository_submodules=True,
+    branch=BRANCH
 )
 
 ################
@@ -97,7 +112,7 @@ Stage1 += apt_get(ospackages=['libpython3.12-dev', 'libopenmpi-dev',
                               'python3.12-venv', 'python3-pip',
                               'python3-wheel', 'python3-pip-whl',
                               'libvtk9-dev', 'dvipng', 'unzip',
-                              'make', 'busybox', 'git', 'rsync'])
+                              'make', 'busybox', 'git', 'rsync', 'wget'])
 
 # Install EXP into the runtime image
 #
@@ -106,9 +121,14 @@ Stage1 += copy(_from='devel',
 Stage1 += copy(_from='devel',
                src='/usr/local/EXP/lib', dest='/usr/local/EXP/lib')
 Stage1 += copy(_from='devel',
-               src='/usr/local/EXP/doc', dest='/var/www/html')
+                src='/usr/local/EXP/include', dest='/usr/local/EXP/include')
 
-# Add Python venv
+# Copy documentation from GitHub Pages
+#
+Stage1 += shell(commands=['mkdir -p /var/www/html', 'cd /var/www/html', 'wget -r -nH --cut-dirs=1 https://exp-code.github.io/EXP-docs/'])
+
+# Add Python venv (needed for Ubuntu 24.04)
+#
 Stage1 += shell(commands=['python3 -m venv /opt/venv', '. /opt/venv/bin/activate'])
 
 # Add Python and EXP to the path and library paths
@@ -118,22 +138,26 @@ Stage1 += environment(variables={'LIBRARY_PATH': '/usr/local/EXP/lib'})
 Stage1 += environment(variables={'LD_LIBRARY_PATH': '/usr/local/EXP/lib'})
 Stage1 += environment(variables={'PYTHONPATH': '/opt/venv/lib/python3.12/site-packages:/usr/local/EXP/lib/python3.12/site-packages'})
 
-# Remove ubuntu user from the container
+# Remove ubuntu user from the container (needed for Ubuntu 24.04)
 #
 Stage1 += shell(commands=['userdel -f ubuntu', 'rm -rf /home/ubuntu'])
 
 # Some packages needed or useful for running pyEXP
 #
-Stage1 += pip(packages=['numpy', 'scipy', 'matplotlib', 'jupyter', 'h5py', 'mpi4py', 'PyYAML', 'k3d', 'pandas', 'astropy', 'gala', 'galpy', 'pynbody', 'jupyterlab', 'jupyterhub', 'ipyparallel'], pip='/opt/venv/bin/pip3', ospackages=['python3-pip', 'python3-setuptools', 'python3-wheel', 'python3-pip-whl'])
+Stage1 += pip(packages=['numpy', 'scipy', 'matplotlib', 'jupyter', 'h5py', 'mpi4py', 'PyYAML', 'pandas', 'astropy', 'galpy', 'pynbody', 'jupyterlab', 'jupyterlab_widgets', 'ipywidgets', 'k3d==2.16.1', 'jupyterhub', 'ipyparallel'], pip='/opt/venv/bin/pip3', ospackages=['python3-pip', 'python3-setuptools', 'python3-wheel', 'python3-pip-whl'])
 
-# Work around for AGAMA
+# Work around to install AGAMA
 #
 Stage1 += shell(commands=['pip3 install --config-settings --build-option=--yes --no-build-isolation agama'])
 
+# Build Gala with EXP support
+#
+Stage1 += shell(commands=['cd /usr/local', 'export GIT_SSL_NO_VERIFY=1', 'git clone https://github.com/adrn/gala.git', 'cd gala', 'export GALA_EXP_PREFIX=/usr/local/EXP/', 'python3 -m pip install -ve .'])
+
 # Add EXP examples to /usr/local
 #
-Stage1 += shell(commands=['cd /usr/local',  'export GIT_SSL_NO_VERIFY=1', 'git clone https://github.com/EXP-code/EXP-examples EXP-examples', 'git clone https://github.com/EXP-code/pyEXP-examples pyEXP-examples', 'cd pyEXP-examples', 'git checkout MinorUpdates'])
+Stage1 += shell(commands=['cd /usr/local',  'export GIT_SSL_NO_VERIFY=1', 'git clone https://github.com/EXP-code/EXP-examples EXP-examples', 'git clone https://github.com/EXP-code/pyEXP-examples pyEXP-examples', 'git clone https://github.com/EXP-code/EXP-tools'])
 
 # Make data directories world read/write
 #
-Stage1 += shell(commands=['chmod -R 777 /opt/venv', 'chmod -R 777 /usr/local/pyEXP-examples', 'chmod -R 777 /usr/local/EXP-examples'])
+Stage1 += shell(commands=['chmod -R 777 /opt/venv', 'chmod -R 777 /usr/local/pyEXP-examples', 'chmod -R 777 /usr/local/EXP-examples', 'chmod -R 777 /usr/local/EXP-tools'])

--- a/README.md
+++ b/README.md
@@ -69,4 +69,5 @@ README](/Docker/README.md) for more details.
 - The Docker container includes an internal MPI installation without
   Cuda and many more Python packages preinstalled, including:
   `jupyterlab`, `matplotlib`, `numpy`, `scipy`, `pandas`, `mpi4py`,
-  `h5py`, `pyYAML`, `astropy`, `galpy`, `k3d` and `ipyparallel`.
+  `h5py`, `pyYAML`, `gala` with EXP support, `astropy`, `galpy`, `k3d`
+  and `ipyparallel`.


### PR DESCRIPTION
Updates the Dockerfile with the following changes:

- gala is now installed from source, instead of from PyPI. This allows building gala with EXP support according to the instructions at https://gala.adrian.pw/en/latest/tutorials/exp.html

- Removed a checkout of the haloVel branch of pyEXP-examples, as this branch no longer exists. 

NOTE: This update requires that the bug fix in PR 218 in the EXP repo is implemented, so that gala compatibility with the main branch of EXP is restored. 